### PR TITLE
Hotfix: DAV droid sent request with dtend := None

### DIFF
--- a/radicale_storage_by_index/__init__.py
+++ b/radicale_storage_by_index/__init__.py
@@ -207,10 +207,10 @@ class Collection(FileSystemCollection):
         self._fill_request(filters, request)
         if not request:
             return super().get_all_filtered(filters)
-        if 'dtstart' in request:
+        if 'dtstart' in request and request['dtstart'] is not None:
             request['dtstart'] = self.dt_to_timestamp(
                 datetime.strptime(request['dtstart'], "%Y%m%dT%H%M%SZ"))
-        if 'dtend' in request:
+        if 'dtend' in request and request['dtend'] is not None:
             request['dtend'] = self.dt_to_timestamp(
                 datetime.strptime(request['dtend'], "%Y%m%dT%H%M%SZ"))
 


### PR DESCRIPTION
I experienced an Issue with DAVdroid that prevented syncing. :frowning_man:
['dtend'] was set, but to None, this resulted in -215: datetime.strptime(request['dtend'] ... throwing an error.
As a preemptive measure I patched dtstart as well :dagger: I did not go deeper, because I experienced this in production and tend to fix bugs like these en-passant.